### PR TITLE
docs: Remove Quick Start and style guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,44 +8,8 @@ Orbit is a Vue.js UI Component Library built on a beautiful, cohesive design sys
 Orbit includes over 50 easy to use components and enables you to quickly construct clean and scalable applications.
 
 ## Documentation
-- [Orbit Style Guide](http://orbit.weebly.net) — [Internal Devs Only] Live examples and component docs
+- Orbit Style Guide - Coming soon
 - [Contribution Guide](/.github/CONTRIBUTING.md) - Learn about Orbit component development, testing, and release steps
-
-## Quick start
-#### #1 Add Orbit as a dependency
-```
-npm install --save @square/orbit
-```
-
-#### #2 Import the CSS
-Import the following CSS file as an asset to your build. <strong>Do not</strong> @import them into the style tag of your App.vue, as doing so will unecessarily pre-process them.
-
-<ul>
-<li><strong>@square/orbit/styles.css</strong>: includes all the base css for orbit components</li>
-</ul>
-
-#### #3 Import an Orbit component
-<p>Update /src/App.vue with the following:</p>
-
-```
-<template>
-  <div id="app">
-    <h1>Orbit v2</h1>
-    <o-button>Button</o-button>
-  </div>
-</template>
-
-<script>
-  // Components are imported individually as needed.
-  // Note the object {} syntax. 'import OButton' will not work.
-  import { OButton } from 'orbit-ui/components/Button';
-
-  export default {
-    name: 'app',
-    components: { OButton }
-  }
-</script>
-```
 
 ## Browser Support
 Orbit supports [all evergreen browsers](/.browserslistrc).


### PR DESCRIPTION
**Describe the problem prior to this PR:**
- Quick start steps will not work till a release of Orbit is published to npm.
- Style guide link is not available at this time.

**Describe the changes in this PR:**
Remove Quick start section and Style guide link temporarily.
